### PR TITLE
refactor: BaseEntity의 equals, hashCode 개선 및 중복 코드 제거 #7

### DIFF
--- a/src/main/java/com/team11/hrbank/module/domain/BaseEntity.java
+++ b/src/main/java/com/team11/hrbank/module/domain/BaseEntity.java
@@ -6,8 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PreUpdate;
 import java.time.Instant;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -15,11 +15,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
 public abstract class BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
   protected Long id;
 
   @CreatedDate
@@ -30,8 +32,4 @@ public abstract class BaseEntity {
   @Column(name = "updated_at")
   protected Instant updatedAt;
 
-  @PreUpdate
-  public void preUpdate() {
-    this.updatedAt = Instant.now();
-  }
 }


### PR DESCRIPTION
- @EqualsAndHashCode(onlyExplicitlyIncluded = true) 어노테이션 추가하여 ID 기반 비교로 변경
- @LastModifiedDate가 이미 updatedAt 필드를 자동 관리하므로 중복된 @PreUpdate 메서드 제거